### PR TITLE
Source files located by 'find' to allow subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ LC_FILES := $(wildcard $(LIBRARYPATH)/*/*.c)
 LCPP_FILES := $(wildcard $(LIBRARYPATH)/*/*.cpp)
 TC_FILES := $(wildcard $(COREPATH)/*.c)
 TCPP_FILES := $(wildcard $(COREPATH)/*.cpp)
-C_FILES := $(wildcard src/*.c)
-CPP_FILES := $(wildcard src/*.cpp)
+C_FILES := $(shell find src/ -name '*.c')
+CPP_FILES := $(shell find src/ -name '*.cpp')
 INO_FILES := $(wildcard src/*.ino)
 
 # include paths for libraries


### PR DESCRIPTION
Larger projects will probably want to make use of subdirectories in `src/`, using `shell find` allows this