### PR TITLE
fix link error for Teensy 3.5/3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TARGET = $(notdir $(CURDIR))
 
 # The teensy version to use, 30, 31, 35, 36, or LC
-TEENSY = 30
+TEENSY = 36
 
 # Set to 24000000, 48000000, or 96000000 to set CPU core speed
 TEENSY_CORE_SPEED = 48000000
@@ -81,12 +81,12 @@ else ifeq ($(TEENSY), 35)
     CPPFLAGS += -D__MK64FX512__ -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
     LDSCRIPT = $(COREPATH)/mk64fx512.ld
     LDFLAGS += -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -T$(LDSCRIPT)
-    LIBS += -larm_cortexM4lf_math
+    LIBS += -larm_cortexM4l_math
 else ifeq ($(TEENSY), 36)
     CPPFLAGS += -D__MK66FX1M0__ -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
     LDSCRIPT = $(COREPATH)/mk66fx1m0.ld
     LDFLAGS += -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -T$(LDSCRIPT)
-    LIBS += -larm_cortexM4lf_math
+    LIBS += -larm_cortexM4l_math
 else
     $(error Invalid setting for TEENSY)
 endif


### PR DESCRIPTION
remove "f" from "libarm_cortexM4lf_math" library filename